### PR TITLE
Agent subscription

### DIFF
--- a/app/connectors/models/subscription/FERequest.scala
+++ b/app/connectors/models/subscription/FERequest.scala
@@ -25,7 +25,10 @@ case class FERequest(nino: String,
                      accountingPeriodStart: Option[DateModel] = None,
                      accountingPeriodEnd: Option[DateModel] = None,
                      tradingName: Option[String] = None,
-                     cashOrAccruals: Option[String] = None)
+                     cashOrAccruals: Option[String] = None,
+                     // enrolUser must be set to false for agent
+                     enrolUser: Boolean = false
+                    )
 
 object FERequest {
   implicit val format = Json.format[FERequest]

--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -54,7 +54,7 @@ class CheckYourAnswersController @Inject()(val baseConfig: BaseControllerConfig,
     implicit request =>
       keystoreService.fetchAll() flatMap {
         case Some(source) =>
-          val nino = user.nino.fold("")(x => x)
+          val nino = source.getNino().get
           middleService.submitSubscription(nino, source.getSummary()).flatMap {
             case Some(FESuccessResponse(id)) =>
               keystoreService.saveSubscriptionId(id).map(_ => Redirect(controllers.routes.ConfirmationController.showConfirmation()))

--- a/app/services/CacheUtil.scala
+++ b/app/services/CacheUtil.scala
@@ -20,12 +20,15 @@ import forms.IncomeSourceForm
 import models._
 import play.api.libs.json.Reads
 import uk.gov.hmrc.http.cache.client.CacheMap
+import utils.Implicits._
 
 object CacheUtil {
 
   implicit class CacheMapUtil(cacheMap: CacheMap) {
 
     import services.CacheConstants._
+
+    def getNino()(implicit read: Reads[ClientDetailsModel]): Option[String] = cacheMap.getEntry(ClientDetails).fold(None: Option[String])(x => x.nino.replace(" ", ""))
 
     def getIncomeSource()(implicit read: Reads[IncomeSourceModel]): Option[IncomeSourceModel] = cacheMap.getEntry(IncomeSource)
 

--- a/test/connectors/mocks/MockHttp.scala
+++ b/test/connectors/mocks/MockHttp.scala
@@ -45,9 +45,21 @@ trait MockHttp extends MockTrait {
     )(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(status, Some(response))))
   }
 
+  def verifyHttpPost[I](url: Option[String] = None, body: Option[I] = None)(count: Int): Unit = {
+    lazy val urlMatcher = url.fold(ArgumentMatchers.any[String]())(x => ArgumentMatchers.eq(x))
+    lazy val bodyMatcher = body.fold(ArgumentMatchers.any[I]())(x => ArgumentMatchers.eq(x))
+    verify(mockHttpPost, times(count)).POST[I, HttpResponse](urlMatcher, bodyMatcher, ArgumentMatchers.any()
+    )(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())
+  }
+
   def setupMockHttpPostEmpty(url: Option[String] = None)(status: Int, response: JsValue): Unit = {
     lazy val urlMatcher = url.fold(ArgumentMatchers.any[String]())(x => ArgumentMatchers.eq(x))
     when(mockHttpPost.POSTEmpty[HttpResponse](urlMatcher)(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(status, Some(response))))
+  }
+
+  def verifyMockHttpPostEmpty(url: Option[String] = None)(count: Int): Unit = {
+    lazy val urlMatcher = url.fold(ArgumentMatchers.any[String]())(x => ArgumentMatchers.eq(x))
+    verify(mockHttpPost, times(count)).POSTEmpty[HttpResponse](urlMatcher)(ArgumentMatchers.any(), ArgumentMatchers.any())
   }
 
   def setupMockHttpGet(url: Option[String] = None)(status: Int, response: Option[JsValue]): Unit = {

--- a/test/connectors/models/subscription/FERequestSpec.scala
+++ b/test/connectors/models/subscription/FERequestSpec.scala
@@ -24,7 +24,8 @@ import utils.TestConstants
 class FERequestSpec extends UnitSpec {
 
   "FERequest" should {
-    "Provide the correct reader for FERequest" in {
+    "Provide the correct writer for FERequest" in {
+      // the default parameter should set enroluser to false
       val feRequest = FERequest(
         nino = TestConstants.testNino,
         incomeSource = Business
@@ -34,7 +35,8 @@ class FERequestSpec extends UnitSpec {
       val expected = Json.fromJson[FERequest](
         s"""{"nino" : "${TestConstants.testNino}",
            | "isAgent" : false,
-           | "incomeSource":"${IncomeSourceType.business}"}""".stripMargin).get
+           | "incomeSource":"${IncomeSourceType.business}",
+           | "enrolUser" : false}""".stripMargin).get
       val actual = Json.fromJson[FERequest](request).get
       actual shouldBe expected
     }

--- a/test/services/CacheUtilSpec.scala
+++ b/test/services/CacheUtilSpec.scala
@@ -62,7 +62,9 @@ class CacheUtilSpec extends UnitTestTrait {
       // for the property only journey, this should only populate the subset of views
       // relevant to the journey
       val overPopulatedPropertyCacheMap =
-        testCacheMap(testIncomeSourceProperty,
+        testCacheMap(
+          testClientDetails,
+          testIncomeSourceProperty,
           testOtherIncomeNo,
           testAccountingPeriodPriorCurrent,
           testAccountingPeriod,

--- a/test/utils/TestModels.scala
+++ b/test/utils/TestModels.scala
@@ -46,7 +46,9 @@ object TestModels extends Implicits {
   val emptyCacheMap = CacheMap("", Map())
 
   val testCacheMap: CacheMap =
-    testCacheMap(incomeSource = testIncomeSourceBoth,
+    testCacheMap(
+      clientDetailsModel = testClientDetails,
+      incomeSource = testIncomeSourceBoth,
       otherIncome = testOtherIncomeNo,
       accountingPeriodPrior = testAccountingPeriodPriorCurrent,
       accountingPeriodDate = testAccountingPeriod,
@@ -54,7 +56,27 @@ object TestModels extends Implicits {
       accountingMethod = testAccountingMethod,
       terms = testTerms)
 
-  def testCacheMap(incomeSource: Option[IncomeSourceModel] = None,
+  def testCacheMapCustom(
+                          clientDetailsModel: Option[ClientDetailsModel] = testClientDetails,
+                          incomeSource: Option[IncomeSourceModel] = testIncomeSourceBoth,
+                          otherIncome: Option[OtherIncomeModel] = testOtherIncomeNo,
+                          accountingPeriodPrior: Option[AccountingPeriodPriorModel] = testAccountingPeriodPriorCurrent,
+                          accountingPeriodDate: Option[AccountingPeriodModel] = testAccountingPeriod,
+                          businessName: Option[BusinessNameModel] = testBusinessName,
+                          accountingMethod: Option[AccountingMethodModel] = testAccountingMethod,
+                          terms: Option[TermModel] = testTerms): CacheMap =
+    testCacheMap(
+      clientDetailsModel = clientDetailsModel,
+      incomeSource = incomeSource,
+      otherIncome = otherIncome,
+      accountingPeriodPrior = accountingPeriodPrior,
+      accountingPeriodDate = accountingPeriodDate,
+      businessName = businessName,
+      accountingMethod = accountingMethod,
+      terms = terms)
+
+  def testCacheMap(clientDetailsModel: Option[ClientDetailsModel] = None,
+                   incomeSource: Option[IncomeSourceModel] = None,
                    otherIncome: Option[OtherIncomeModel] = None,
                    accountingPeriodPrior: Option[AccountingPeriodPriorModel] = None,
                    accountingPeriodDate: Option[AccountingPeriodModel] = None,
@@ -63,6 +85,7 @@ object TestModels extends Implicits {
                    terms: Option[TermModel] = None): CacheMap = {
     val emptyMap = Map[String, JsValue]()
     val map: Map[String, JsValue] = Map[String, JsValue]() ++
+      clientDetailsModel.fold(emptyMap)(model => Map(ClientDetails -> ClientDetailsModel.format.writes(model))) ++
       incomeSource.fold(emptyMap)(model => Map(IncomeSource -> IncomeSourceModel.format.writes(model))) ++
       otherIncome.fold(emptyMap)(model => Map(OtherIncome -> OtherIncomeModel.format.writes(model))) ++
       accountingPeriodPrior.fold(emptyMap)(model => Map(AccountingPeriodPrior -> AccountingPeriodPriorModel.format.writes(model))) ++


### PR DESCRIPTION
updated the FERequest with enroluser param and set it to false, when calling subscription the nino is supplied by the agent's answer instead of from the agent's user profile